### PR TITLE
Remove underline from positions button

### DIFF
--- a/assets/sass/components/header.sass
+++ b/assets/sass/components/header.sass
@@ -4,6 +4,9 @@
     justify-content: space-between
     font-family: var(--font)
 
+    a
+        text-decoration: none
+
     @media screen and (max-width: $breakpoint)
         flex-direction: column
         justify-content: center


### PR DESCRIPTION
This line seems to remove the underline from the positions button.

Tried it out several times and it worked